### PR TITLE
Use acme.sh for certificate issuing/renewal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ VOLUME /opt/rproxy/private
 RUN rm -rfv /etc/ssl/acme/ && \
     ln -sfv /opt/rproxy/private/acme /etc/ssl/acme
 
+RUN rm -rfv /root/.acme.sh && \
+    ln -sfv /opt/rproxy/private/acme.sh /root/.acme.sh
+
 COPY etc/ /etc/nginx/
 COPY bin/ ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:alpine
 
 RUN apk update --no-cache && \
-    apk add acme-client libressl
+    apk add openssl acme.sh
 
 WORKDIR /opt/rproxy/
 VOLUME /opt/rproxy/private

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update --no-cache && \
 
 WORKDIR /opt/rproxy/
 VOLUME /opt/rproxy/private
-RUN rm -rv /etc/ssl/acme/ && \
+RUN rm -rfv /etc/ssl/acme/ && \
     ln -sfv /opt/rproxy/private/acme /etc/ssl/acme
 
 COPY etc/ /etc/nginx/

--- a/bin/install-cert.sh
+++ b/bin/install-cert.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+
+domain=${1?need the domain name as the first parameter}
+
+echo "rproxy: installing cert for $domain"
+acme.sh --install-cert -d "'$domain'" \
+  --key-file "/etc/ssl/acme/private/$domain/privkey.pem" \
+  --fullchain-file "/etc/ssl/acme/$domain/fullchain.pem" \
+  --reloadcmd /opt/rproxy/reload-nginx.sh

--- a/bin/install-cert.sh
+++ b/bin/install-cert.sh
@@ -3,6 +3,9 @@ set -e
 
 domain=${1?need the domain name as the first parameter}
 
+mkdir -pv "/etc/ssl/acme/$domain/"
+mkdir -pv "/etc/ssl/acme/private/$domain/"
+
 echo "rproxy: installing cert for $domain"
 acme.sh --install-cert -d "$domain" \
   --key-file "/etc/ssl/acme/private/$domain/privkey.pem" \

--- a/bin/install-cert.sh
+++ b/bin/install-cert.sh
@@ -4,7 +4,7 @@ set -e
 domain=${1?need the domain name as the first parameter}
 
 echo "rproxy: installing cert for $domain"
-acme.sh --install-cert -d "'$domain'" \
+acme.sh --install-cert -d "$domain" \
   --key-file "/etc/ssl/acme/private/$domain/privkey.pem" \
   --fullchain-file "/etc/ssl/acme/$domain/fullchain.pem" \
   --reloadcmd /opt/rproxy/reload-nginx.sh

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -3,6 +3,8 @@ if [ ! -d  ./private/acme ] ; then
   mkdir -pv ./private/acme
 fi
 
+mkdir -pv ./private/acme.sh
+
 if [ ! -f ./private/dhparam.pem ] ; then
   sh $(dirname $0)/setup/generate-dhparam.sh
 fi

--- a/bin/setup/issue.sh
+++ b/bin/setup/issue.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+domain=${1?need the domain name as the first parameter}
+
+echo "rproxy: issuing for $domain"
+acme.sh --issue -d "'$domain'" --server Letsencrypt.org -w /var/www/acme/ --log

--- a/bin/setup/issue.sh
+++ b/bin/setup/issue.sh
@@ -4,4 +4,4 @@ set -e
 domain=${1?need the domain name as the first parameter}
 
 echo "rproxy: issuing for $domain"
-acme.sh --issue -d "'$domain'" --server Letsencrypt.org -w /var/www/acme/ --log
+acme.sh --issue -d "$domain" --server Letsencrypt.org -w /var/www/acme/ --log

--- a/etc/includes/acme.inc
+++ b/etc/includes/acme.inc
@@ -1,3 +1,3 @@
 location /.well-known/acme-challenge/ {
-    alias /var/www/acme/;
+    alias /var/www/acme/.well-known/acme-challenge/;
 }


### PR DESCRIPTION
Add `acme.sh` and helper scripts around setting that up

some cleanup is still needed:
- https://github.com/pretorh/https-reverse-proxy-docker/issues/1
- https://github.com/pretorh/https-reverse-proxy-docker/issues/3