### PR TITLE
documentation: fix typos, extract issue script to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,8 @@ serve multiple hostnames (reverse proxy)
 ## Set up / first run
 
 To install a new domain, start the docker container with the mount point (at least into `/opt/rproxy/private`)
-and http port (`-p 80:80`). Use the `domain-setup.sh` script to issue certificates and install them:
-
-```bash
-docker run --rm -ti \
-    -p 80:80 \
-    -v $(pwd)/.private:/opt/rproxy/private \
-    pretorh/https-reverse-proxy:latest ./domain-setup.sh domain1.tld domain2.tld ...
-```
+and http port (`-p 80:80`). Use the `domain-setup.sh` script to issue certificates and install them. See 
+`examples/issue-certificates.sh` for an example.
 
 ## Hosting
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: pretorh/https-reverse-proxy
     ports:
       - 80:80
-      - 433:433
+      - 443:443
     environment:
       # set the day of week and hour when certificates should be renewed
       - CRON_DAY=SUN

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   rproxy:
-    image: pretorh/https-reverse-proxy
+    image: pretorh/https-reverse-proxy:latest
     ports:
       - 80:80
       - 443:443

--- a/examples/issue-certificates.sh
+++ b/examples/issue-certificates.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-# example command for isssuing certificates, for the domains used in sites/*.conf
+# example command for issuing certificates, for the domains used in sites/*.conf
 docker run --rm -ti \
     -p 80:80 \
     -v "$(pwd)/.private":/opt/rproxy/private \

--- a/examples/issue-certificates.sh
+++ b/examples/issue-certificates.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# example command for isssuing certificates, for the domains used in sites/*.conf
+docker run --rm -ti \
+    -p 80:80 \
+    -v "$(pwd)/.private":/opt/rproxy/private \
+    pretorh/https-reverse-proxy:latest \
+    ./domain-setup.sh simple.domain1.example.com web.domain1.example.com combined.domain1.example.com

--- a/examples/sites/combined.conf
+++ b/examples/sites/combined.conf
@@ -6,7 +6,7 @@ server {
   # load ssl certificates and setup parameters
   # note these need to exist already when nginx starts up
   ssl_certificate /etc/ssl/acme/combined.domain1.example.com/fullchain.pem;
-  ssl_certificate_key /etc/ssl/acme/combined.private/domain1.example.com/privkey.pem;
+  ssl_certificate_key /etc/ssl/acme/private/combined.domain1.example.com/privkey.pem;
   include /etc/nginx/includes/ssl-params.inc;
 
   # proxy all "api" requests to the `web` service (in `docker-compose.yml`) on port 8080

--- a/examples/sites/simple.conf
+++ b/examples/sites/simple.conf
@@ -6,7 +6,7 @@ server {
   # load ssl certificates and setup parameters
   # note these need to exist already when nginx starts up
   ssl_certificate /etc/ssl/acme/simple.domain1.example.com/fullchain.pem;
-  ssl_certificate_key /etc/ssl/acme/simple.private/domain1.example.com/privkey.pem;
+  ssl_certificate_key /etc/ssl/acme/private/simple.domain1.example.com/privkey.pem;
   include /etc/nginx/includes/ssl-params.inc;
 
   location / {

--- a/examples/sites/web.conf
+++ b/examples/sites/web.conf
@@ -6,7 +6,7 @@ server {
   # load ssl certificates and setup parameters
   # note these need to exist already when nginx starts up
   ssl_certificate /etc/ssl/acme/web.domain1.example.com/fullchain.pem;
-  ssl_certificate_key /etc/ssl/acme/web.private/domain1.example.com/privkey.pem;
+  ssl_certificate_key /etc/ssl/acme/private/web.domain1.example.com/privkey.pem;
   include /etc/nginx/includes/ssl-params.inc;
 
   # proxy all requests to the `web` service (in `docker-compose.yml`) on port 8080


### PR DESCRIPTION
fix typos in examples:
- `ssl_certificate_key` paths
- docker compose https port

examples improvements:
- explicitly use `latest` tag in docker compose 
- extract `examples/issue-certificates.sh` from README