### PR TITLE
Setup manual test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .private/
+hrp-tests/

--- a/bin/test-hosted-cert.sh
+++ b/bin/test-hosted-cert.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env sh
 
-HOST=${1-localhost}
+domain=$1
+connect=${2-localhost:443}
 
 # based on https://serverfault.com/a/661982
 # but only print some of the info
 echo \
-  | openssl s_client -showcerts -servername "$HOST" -connect "$HOST:443" 2>/dev/null \
+  | openssl s_client -showcerts -servername "$domain" -connect "$connect" 2>/dev/null \
   | openssl x509 -inform pem -noout -subject -issuer -email -dates -fingerprint

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+image_tag=${1?'need the image tag as first argument'}
+test_domain=${2?'need the domain to test for as the 2nd argument'}
+http_port=${HTTP_PORT-80}
+https_port=${HTTPS_PORT-443}
+
+root_test_dir=./hrp-tests
+
+full_image_name="pretorh/https-reverse-proxy:$image_tag"
+port_map_http="$http_port:80"
+port_map_https="$https_port:443"
+
+config_file() {
+  file=$1
+  example="examples/$file"
+  output="$root_test_dir/$file"
+  mkdir -p "$(dirname "$output")"
+
+  echo "$example -> sed -> $output"
+  sed \
+    -e 's|pretorh/https-reverse-proxy:latest|'"$full_image_name"'|' \
+    -e 's|80:80|'"$port_map_http"'|' \
+    -e 's|443:443|'"$port_map_https"'|' \
+    -e 's|domain-setup.sh .*|domain-setup.sh '"$test_domain"'|g' \
+    -e 's|combined.domain1.example.com|'"$test_domain"'|g' \
+    "$example" > "$output"
+}
+
+echo "Configuring examples for testing:"
+echo "- using $full_image_name on ports $port_map_http and $port_map_https"
+echo "- domain: $test_domain"
+echo "- test directory: $root_test_dir"
+
+mkdir -p $root_test_dir/{sites/,public/web-and-api/}
+cp -v examples/public/web-and-api/index.html $root_test_dir/public/web-and-api/
+config_file issue-certificates.sh
+config_file docker-compose.yml
+config_file sites/combined.conf


### PR DESCRIPTION
Add script that uses the examples, modified based on arguments, that sets up a basic site that can be used to test initial issuing and site startups

Change `bin/test-hosted-cert.sh` to take the server name as the first argument, and specifying the connect-to server as the second argument (defaults to https on localhost)

Can _manually_ use this script to test issuing and startup:
```shell
sh ./issue-certificates.sh
docker-compose up --detach
docker-compose exec rproxy ./test-hosted-cert.sh web.example.com > public/web-and-api/cert.txt
```

This can later be expanded to be more automated (ex fetching examples/pushing the results to a hosted server, running the checks)