### PR TITLE
move ssl dirs (breaking change)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update --no-cache && \
     apk add openssl acme.sh && \
     # symlink acme.sh, ssl certs from volume
     rm -rfv /etc/ssl/acme/ /root/.acme.sh && \
-    ln -sfv /opt/rproxy/private/acme /etc/ssl/acme && \
+    ln -sfv /opt/rproxy/private/certs /etc/ssl/acme && \
     ln -sfv /opt/rproxy/private/acme.sh /root/.acme.sh
 
 WORKDIR /opt/rproxy/

--- a/bin/domain-setup.sh
+++ b/bin/domain-setup.sh
@@ -6,7 +6,7 @@ nginx
 
 echo "Set up directories"
 mkdir -pv ./private/acme.sh
-mkdir -pv ./private/acme
+mkdir -pv ./private/certs
 
 echo "Issuing certificates"
 for domain in "$@" ; do

--- a/bin/install-cert.sh
+++ b/bin/install-cert.sh
@@ -6,8 +6,13 @@ domain=${1?need the domain name as the first parameter}
 mkdir -pv "/etc/ssl/acme/$domain/"
 mkdir -pv "/etc/ssl/acme/private/$domain/"
 
+reloadcmd=/opt/rproxy/reload-nginx.sh
+if [ "$NO_RELOAD" ] ; then
+  reloadcmd=true
+fi
+
 echo "rproxy: installing cert for $domain"
 acme.sh --install-cert -d "$domain" \
   --key-file "/etc/ssl/acme/$domain/private-key.pem" \
   --fullchain-file "/etc/ssl/acme/$domain/fullchain.pem" \
-  --reloadcmd /opt/rproxy/reload-nginx.sh
+  --reloadcmd "$reloadcmd"

--- a/bin/install-cert.sh
+++ b/bin/install-cert.sh
@@ -8,6 +8,6 @@ mkdir -pv "/etc/ssl/acme/private/$domain/"
 
 echo "rproxy: installing cert for $domain"
 acme.sh --install-cert -d "$domain" \
-  --key-file "/etc/ssl/acme/private/$domain/privkey.pem" \
+  --key-file "/etc/ssl/acme/$domain/private-key.pem" \
   --fullchain-file "/etc/ssl/acme/$domain/fullchain.pem" \
   --reloadcmd /opt/rproxy/reload-nginx.sh

--- a/bin/install-cert.sh
+++ b/bin/install-cert.sh
@@ -4,7 +4,6 @@ set -e
 domain=${1?need the domain name as the first parameter}
 
 mkdir -pv "/etc/ssl/acme/$domain/"
-mkdir -pv "/etc/ssl/acme/private/$domain/"
 
 reloadcmd=/opt/rproxy/reload-nginx.sh
 if [ "$NO_RELOAD" ] ; then

--- a/bin/job/renew-and-reload.sh
+++ b/bin/job/renew-and-reload.sh
@@ -6,7 +6,7 @@ start_file="$(mktemp)"
 updated=0
 if sh /opt/rproxy/renew-certs.sh ; then
   echo "update job successful"
-  if find /opt/rproxy/private/acme/private -type f -name 'privkey.pem' -newer "$start_file" | grep '^' ; then
+  if find /etc/ssl/acme/ -type f -name 'privkey.pem' -newer "$start_file" | grep '^' ; then
     updated=1
   fi
 else

--- a/bin/job/renew-and-reload.sh
+++ b/bin/job/renew-and-reload.sh
@@ -6,7 +6,7 @@ start_file="$(mktemp)"
 updated=0
 if sh /opt/rproxy/renew-certs.sh ; then
   echo "update job successful"
-  if find /etc/ssl/acme/ -type f -name 'privkey.pem' -newer "$start_file" | grep '^' ; then
+  if find /etc/ssl/acme/ -type f -name 'private-key.pem' -newer "$start_file" | grep '^' ; then
     updated=1
   fi
 else

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -2,9 +2,9 @@
 
 root=$(dirname "$0")
 
-if [ ! -d  ./private/acme ] ; then
+if [ ! -d  ./private/certs ] ; then
   sh "$root/setup/first-run-note.sh"
-  mkdir -pv ./private/acme
+  mkdir -pv ./private/certs
 fi
 
 mkdir -pv ./private/acme.sh

--- a/examples/sites/combined.conf
+++ b/examples/sites/combined.conf
@@ -6,7 +6,7 @@ server {
   # load ssl certificates and setup parameters
   # note these need to exist already when nginx starts up
   ssl_certificate /etc/ssl/acme/combined.domain1.example.com/fullchain.pem;
-  ssl_certificate_key /etc/ssl/acme/private/combined.domain1.example.com/privkey.pem;
+  ssl_certificate_key /etc/ssl/acme/combined.domain1.example.com/private-key.pem;
   # research before using/cherry-pick from: include /etc/nginx/includes/ssl-params.inc;
 
   # proxy all "api" requests to the `web` service (in `docker-compose.yml`) on port 8080

--- a/examples/sites/simple.conf
+++ b/examples/sites/simple.conf
@@ -6,7 +6,7 @@ server {
   # load ssl certificates and setup parameters
   # note these need to exist already when nginx starts up
   ssl_certificate /etc/ssl/acme/simple.domain1.example.com/fullchain.pem;
-  ssl_certificate_key /etc/ssl/acme/private/simple.domain1.example.com/privkey.pem;
+  ssl_certificate_key /etc/ssl/acme/simple.domain1.example.com/private-key.pem;
   # research before using/cherry-pick from: include /etc/nginx/includes/ssl-params.inc;
 
   location / {

--- a/examples/sites/web.conf
+++ b/examples/sites/web.conf
@@ -6,7 +6,7 @@ server {
   # load ssl certificates and setup parameters
   # note these need to exist already when nginx starts up
   ssl_certificate /etc/ssl/acme/web.domain1.example.com/fullchain.pem;
-  ssl_certificate_key /etc/ssl/acme/private/web.domain1.example.com/privkey.pem;
+  ssl_certificate_key /etc/ssl/acme/web.domain1.example.com/private-key.pem;
   # research before using/cherry-pick from: include /etc/nginx/includes/ssl-params.inc;
 
   # proxy all requests to the `web` service (in `docker-compose.yml`) on port 8080


### PR DESCRIPTION
fixes #6 

## breaking changes
- rename `acme` -> `certs` in mounted `./private` directory
- rename and move private key files (`private/$domain/privkey.pem` -> `$domain/private-key.pem`, ie next to the `fullchain.pem` file)

## upgrading

### install to new directories and cleanup old `acme` directory

```
docker run --rm -ti \
    -p 80:80 \
    -v "$(pwd)/.private":/opt/rproxy/private \
    pretorh/https-reverse-proxy \
    sh
```

inside docker:

```
mkdir -pv ./private/certs
NO_RELOAD=1 ./install-cert.sh <domain1>
NO_RELOAD=1 ./install-cert.sh <domain2>
...
rm -rv ./private/acme
```

### update `ssl_certificate_key` path

update all files to use the new path of the private key files:

```diff
ssl_certificate /etc/ssl/acme/combined.domain1.example.com/fullchain.pem;
-  ssl_certificate_key /etc/ssl/acme/private/combined.domain1.example.com/privkey.pem;
+  ssl_certificate_key /etc/ssl/acme/combined.domain1.example.com/private-key.pem;
```
