### PR TITLE
renew: reload once in renew-and-reload job

### DIFF
--- a/bin/install-cert.sh
+++ b/bin/install-cert.sh
@@ -5,9 +5,9 @@ domain=${1?need the domain name as the first parameter}
 
 mkdir -pv "/etc/ssl/acme/$domain/"
 
-reloadcmd=/opt/rproxy/reload-nginx.sh
-if [ "$NO_RELOAD" ] ; then
-  reloadcmd=true
+reloadcmd=true
+if [ "$RELOAD_AFTER" ] ; then
+  reloadcmd=/opt/rproxy/reload-nginx.sh
 fi
 
 echo "rproxy: installing cert for $domain"

--- a/bin/job/renew-and-reload.sh
+++ b/bin/job/renew-and-reload.sh
@@ -14,6 +14,11 @@ else
   updated=-1
 fi
 
+if [ $updated -eq 1 ] ; then
+  echo "certificates renewed, reloading"
+  /opt/rproxy/reload-nginx.sh
+fi
+
 if [ -x /opt/rproxy/private/post-cron.sh ] ; then
   echo "executing post-cron.sh script"
   /opt/rproxy/private/post-cron.sh $updated


### PR DESCRIPTION
change the reload command when installing certs to by default be `true` only (unless `RELOAD_AFTER` env is set)

if any certificates were updated in `renew-and-reload.s`, reload once, before the post-cron job is started